### PR TITLE
PERF: Optimize PasswordValidatorService.cs

### DIFF
--- a/src/SimplePasswordCheck/SimplePasswordCheck.Benchmark/Password/Service/PasswordValidatorService_Benchmark.cs
+++ b/src/SimplePasswordCheck/SimplePasswordCheck.Benchmark/Password/Service/PasswordValidatorService_Benchmark.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace SimplePasswordCheck.Benchmark.Password.Service
 {  
+    [MemoryDiagnoser]
     public class PasswordValidatorServiceBenchmark
     {
         [Params("AbTp9!fok",

--- a/src/SimplePasswordCheck/SimplePasswordCheck/Core/Password/Service/PasswordValidatorService.cs
+++ b/src/SimplePasswordCheck/SimplePasswordCheck/Core/Password/Service/PasswordValidatorService.cs
@@ -10,20 +10,20 @@ namespace SimplePasswordCheck.Core.Password.Service
     public class PasswordValidatorService : IPasswordValidatorService
     {  
 
-        private readonly char[] upperCaseLetters = new char[] {
+        private static readonly char[] UpperCaseLetters = new char[] {
                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'
             };
 
-        private readonly char[] lowerCaseLetters = new char[] {
+        private static readonly char[] LowerCaseLetters = new char[] {
                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
             };
 
-        private readonly char[] numbers = new char[]
+        private static readonly char[] Numbers = new char[]
         {
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'
         };
 
-        private readonly char[] specialCharactersAllowed = new char[]
+        private static readonly char[] SpecialCharactersAllowed = new char[]
        {           
             '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '+'
        };
@@ -41,10 +41,10 @@ namespace SimplePasswordCheck.Core.Password.Service
             }
 
             bool validated = password.Any(letter =>                                                
-                                                (numbers.Any(n => n == letter) ||
-                                                upperCaseLetters.Any(u => u == letter) ||
-                                                lowerCaseLetters.Any(l => l == letter) ||
-                                                specialCharactersAllowed.Any(s => s == letter)));
+                                                (Numbers.Any(n => n == letter) ||
+                                                UpperCaseLetters.Any(u => u == letter) ||
+                                                LowerCaseLetters.Any(l => l == letter) ||
+                                                SpecialCharactersAllowed.Any(s => s == letter)));
 
             return validated;
         }


### PR DESCRIPTION
Hi @hederson, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
|                Method |       password |         Mean |       Error |      StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |--------------- |-------------:|------------:|------------:|-------:|------:|------:|----------:|
|  ValidatePasswordLinq |       AAAbbbCc |    83.357 ns |   1.7162 ns |   2.1077 ns | 0.1606 |     - |     - |     336 B |
| ValidatePasswordRegex |       AAAbbbCc |     8.765 ns |   0.2125 ns |   0.2837 ns | 0.0115 |     - |     - |      24 B |
|  ValidatePasswordLinq |      AbTp9 fok | 1,118.489 ns |  18.1629 ns |  19.4341 ns | 0.5493 |     - |     - |    1152 B |
| ValidatePasswordRegex |      AbTp9 fok | 3,236.560 ns |  61.9445 ns | 146.0105 ns | 0.0076 |     - |     - |      24 B |
|  ValidatePasswordLinq |   AbTp9!fek123 | 2,988.644 ns |  55.8086 ns |  57.3113 ns | 1.0414 |     - |     - |    2184 B |
| ValidatePasswordRegex |   AbTp9!fek123 | 5,566.130 ns | 111.2594 ns | 191.9170 ns | 0.0076 |     - |     - |      24 B |
|  ValidatePasswordLinq | AbTp9!fek123() | 3,609.045 ns |  70.0475 ns |  68.7960 ns | 1.1559 |     - |     - |    2424 B |
| ValidatePasswordRegex | AbTp9!fek123() | 6,885.118 ns | 126.6876 ns | 275.4084 ns | 0.0076 |     - |     - |      24 B |
|  ValidatePasswordLinq |  AbTp9!fek123) | 3,278.419 ns |  63.6586 ns |  68.1140 ns | 1.0986 |     - |     - |    2304 B |
| ValidatePasswordRegex |  AbTp9!fek123) | 6,085.380 ns | 113.5168 ns | 192.7602 ns | 0.0076 |     - |     - |      24 B |
|  ValidatePasswordLinq |     AbTp9!feka | 2,275.880 ns |  45.5026 ns |  63.7883 ns | 0.9270 |     - |     - |    1944 B |
| ValidatePasswordRegex |     AbTp9!feka | 4,299.798 ns |  84.8791 ns | 196.7203 ns | 0.0076 |     - |     - |      24 B |
|  ValidatePasswordLinq |      AbTp9!foA |   265.704 ns |   5.1811 ns |   5.9665 ns | 0.2637 |     - |     - |     552 B |
| ValidatePasswordRegex |      AbTp9!foA |   574.750 ns |  11.5635 ns |  24.3913 ns | 0.0114 |     - |     - |      24 B |
|  ValidatePasswordLinq |      AbTp9!fok | 1,974.308 ns |  37.3294 ns |  36.6624 ns | 0.8717 |     - |     - |    1824 B |
| ValidatePasswordRegex |      AbTp9!fok | 3,745.471 ns |  73.9936 ns | 177.2840 ns | 0.0114 |     - |     - |      24 B |
|  ValidatePasswordLinq |      AbTp9!foo | 1,438.298 ns |  28.1057 ns |  35.5447 ns | 0.6657 |     - |     - |    1392 B |
| ValidatePasswordRegex |      AbTp9!foo | 4,093.627 ns |  81.9124 ns | 207.0031 ns | 0.0076 |     - |     - |      24 B |

**Benchmarks after changes:**
|                Method |       password |         Mean |       Error |      StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |--------------- |-------------:|------------:|------------:|-------:|------:|------:|----------:|
|  ValidatePasswordLinq |       AAAbbbCc |    17.943 ns |   0.4045 ns |   0.5536 ns | 0.0229 |     - |     - |      48 B |
| ValidatePasswordRegex |       AAAbbbCc |     8.537 ns |   0.2140 ns |   0.2102 ns | 0.0115 |     - |     - |      24 B |
|  ValidatePasswordLinq |      AbTp9 fok | 1,001.221 ns |  19.3940 ns |  27.8143 ns | 0.4120 |     - |     - |     864 B |
| ValidatePasswordRegex |      AbTp9 fok | 3,204.873 ns |  62.9545 ns | 122.7879 ns | 0.0114 |     - |     - |      24 B |
|  ValidatePasswordLinq |   AbTp9!fek123 | 2,814.261 ns |  55.1227 ns |  48.8648 ns | 0.8736 |     - |     - |    1832 B |
| ValidatePasswordRegex |   AbTp9!fek123 | 5,657.064 ns |  98.4533 ns | 175.0006 ns | 0.0076 |     - |     - |      24 B |
|  ValidatePasswordLinq | AbTp9!fek123() | 3,547.418 ns |  67.6252 ns |  72.3582 ns | 0.9880 |     - |     - |    2072 B |
| ValidatePasswordRegex | AbTp9!fek123() | 6,846.069 ns | 135.4365 ns | 206.8258 ns | 0.0076 |     - |     - |      24 B |
|  ValidatePasswordLinq |  AbTp9!fek123) | 2,853.199 ns |  87.0298 ns | 255.2434 ns | 0.9308 |     - |     - |    1952 B |
| ValidatePasswordRegex |  AbTp9!fek123) | 5,133.050 ns | 102.5330 ns | 150.2915 ns | 0.0076 |     - |     - |      24 B |
|  ValidatePasswordLinq |     AbTp9!feka | 1,572.985 ns |  29.9692 ns |  32.0667 ns | 0.7610 |     - |     - |    1592 B |
| ValidatePasswordRegex |     AbTp9!feka | 3,327.851 ns |  66.1471 ns |  99.0059 ns | 0.0114 |     - |     - |      24 B |
|  ValidatePasswordLinq |      AbTp9!foA |   151.093 ns |   2.8315 ns |   2.5101 ns | 0.1261 |     - |     - |     264 B |
| ValidatePasswordRegex |      AbTp9!foA |   399.796 ns |   7.9674 ns |  17.4886 ns | 0.0114 |     - |     - |      24 B |
|  ValidatePasswordLinq |      AbTp9!fok | 1,339.733 ns |  22.2305 ns |  19.7068 ns | 0.7038 |     - |     - |    1472 B |
| ValidatePasswordRegex |      AbTp9!fok | 2,866.042 ns |  53.8050 ns | 104.9424 ns | 0.0114 |     - |     - |      24 B |
|  ValidatePasswordLinq |      AbTp9!foo |   979.921 ns |  15.1521 ns |  14.1732 ns | 0.5264 |     - |     - |    1104 B |
| ValidatePasswordRegex |      AbTp9!foo | 3,353.883 ns |  66.8923 ns | 161.5525 ns | 0.0076 |     - |     - |      24 B |

As you can see the allocations have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!